### PR TITLE
Add missing import of exit

### DIFF
--- a/version.py
+++ b/version.py
@@ -1,5 +1,6 @@
 # Source: https://github.com/Changaco/version.py
 
+from sys import exit
 from os.path import dirname, isdir, join
 import re
 from subprocess import CalledProcessError, check_output


### PR DESCRIPTION
Resolve:

```
In [1]: from version import get_version

In [2]: get_version()
fatal: No names found, cannot describe anything.
Unable to get version number from git tags
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-2-77116a08a28f> in <module>()
----> 1 get_version()

/home/blyenth/dev/company-time-clock/version.py in get_version()
     26         except CalledProcessError:
     27             print('Unable to get version number from git tags')
---> 28             exit(1)
     29 
     30         # PEP 440 compatibility

NameError: global name 'exit' is not defined
```
